### PR TITLE
TACO-365 Add main model and generator

### DIFF
--- a/lib/generators/staged_event/install_generator.rb
+++ b/lib/generators/staged_event/install_generator.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails/generators"
+require "rails/generators/active_record"
+
+module StagedEvent
+  class InstallGenerator < Rails::Generators::Base
+    include Rails::Generators::Migration
+
+    class << self
+      delegate :next_migration_number, to: ActiveRecord::Generators::Base
+    end
+
+    source_paths << File.join(File.dirname(__FILE__), "templates")
+
+    # Generates monolithic migration file that contains all database changes.
+    def create_migration_file
+      migration_template "create_staged_events.rb.erb", "db/migrate/create_staged_events.rb"
+    end
+  end
+end

--- a/lib/generators/staged_event/templates/create_staged_events.rb.erb
+++ b/lib/generators/staged_event/templates/create_staged_events.rb.erb
@@ -1,0 +1,9 @@
+class CreateStagedEvents < ActiveRecord::Migration[6.0]
+  def change
+    create_table :staged_events, id: :uuid do |t|
+      t.string :topic
+      t.binary :data
+      t.datetime :created_at, null: false
+    end
+  end
+end

--- a/lib/generators/staged_event/templates/create_staged_events.rb.erb
+++ b/lib/generators/staged_event/templates/create_staged_events.rb.erb
@@ -1,7 +1,7 @@
 class CreateStagedEvents < ActiveRecord::Migration[6.0]
   def change
-    enable_extension 'uuid-ossp'
-    enable_extension 'pgcrypto'
+    enable_extension "uuid-ossp"
+    enable_extension "pgcrypto"
 
     create_table :staged_events, id: :uuid do |t|
       t.string :topic

--- a/lib/generators/staged_event/templates/create_staged_events.rb.erb
+++ b/lib/generators/staged_event/templates/create_staged_events.rb.erb
@@ -1,5 +1,8 @@
 class CreateStagedEvents < ActiveRecord::Migration[6.0]
   def change
+    enable_extension 'uuid-ossp'
+    enable_extension 'pgcrypto'
+
     create_table :staged_events, id: :uuid do |t|
       t.string :topic
       t.binary :data

--- a/lib/staged_event.rb
+++ b/lib/staged_event.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require "active_record"
+require_relative "staged_event/model"
+require_relative "staged_event/version"

--- a/lib/staged_event/model.rb
+++ b/lib/staged_event/model.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module StagedEvent
+  class Model < ActiveRecord::Base
+    self.table_name = :staged_events
+  end
+end

--- a/lib/staged_event/version.rb
+++ b/lib/staged_event/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module StagedEvent
+  VERSION = "0.0.1"
+end

--- a/staged_event.gemspec
+++ b/staged_event.gemspec
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative "lib/staged_event/version"
+
+Gem::Specification.new do |spec|
+  spec.name        = "staged_event"
+  spec.version     = StagedEvent::VERSION
+  spec.summary     = "StagedEvent"
+  spec.description = "A transactional outbox implementation for Ruby/ActiveRecord"
+  spec.authors     = ["Andrew Cross"]
+  spec.email       = "andrew.cross@freshly.com"
+  spec.files       = Dir["{bin,lib}/**/*", "README.md"]
+  spec.homepage    = "https://github.com/Freshly/staged_event"
+  spec.license     = "MIT"
+
+  spec.add_dependency "activerecord", ">= 6.0.0"
+end
+


### PR DESCRIPTION
https://freshly.atlassian.net/browse/TACO-365

To get this gem started, this PR creates the main model (the `PublishableEvent` replacement) and a generator for that model.

Things like rspecs and serialization are forthcoming, just keeping these PRs small. 

How to test:

1. Clone this gem, take note of the full local path (for example "/Users/andrewcross/code/staged_event").
2. Open the repo where you want to include this gem (for example, Distribution). Add `gem "staged_event", path: "your_path_from_step_1"` to the Gemfile, and then `bundle`.
3. You should now be able to run `rails g staged_event:install` to generate a migration. Run the migration.
4. Open your rails console and do `StagedEvent::Model.create` to make sure the gem is loaded and saving records.