### PR TITLE
TACO-567 Implement publisher process

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,14 @@ GEM
       zeitwerk (~> 2.3)
     around_the_world (0.27.0)
       activesupport (>= 5.2.1)
+    byebug (11.1.3)
     concurrent-ruby (1.1.9)
+    database_cleaner (2.0.1)
+      database_cleaner-active_record (~> 2.0.0)
+    database_cleaner-active_record (2.0.1)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     diff-lcs (1.4.4)
     directive (0.27.0)
       activemodel (>= 5.2.1)
@@ -71,6 +78,8 @@ PLATFORMS
   x86_64-darwin-18
 
 DEPENDENCIES
+  byebug
+  database_cleaner
   faker
   rspec
   sqlite3

--- a/lib/generators/staged_event/templates/initializer.rb.erb
+++ b/lib/generators/staged_event/templates/initializer.rb.erb
@@ -2,7 +2,7 @@
 
 StagedEvent::Configuration.configure do |config|
   config.google_pubsub do |google_pubsub|
-    # Identifier for a PubSub project
+    # Identifier for a Pub/Sub project
     google_pubsub.project_id = "your-project"
     # The contents of the Pub/Sub keyfile as a Hash
     google_pubsub.credentials = {}

--- a/lib/staged_event.rb
+++ b/lib/staged_event.rb
@@ -5,6 +5,9 @@ require "directive"
 require_relative "staged_event/configuration"
 require_relative "staged_event/message_envelope_pb"
 require_relative "staged_event/model"
+require_relative "staged_event/publisher/backoff_timer"
+require_relative "staged_event/publisher/base"
+require_relative "staged_event/publisher_process"
 require_relative "staged_event/version"
 
 module StagedEvent

--- a/lib/staged_event/configuration.rb
+++ b/lib/staged_event/configuration.rb
@@ -10,6 +10,10 @@ module StagedEvent
         option :credentials
         option :topic_map
       end
+
+      nested :publisher do
+        option :batch_size
+      end
     end
   end
 end

--- a/lib/staged_event/publisher/backoff_timer.rb
+++ b/lib/staged_event/publisher/backoff_timer.rb
@@ -11,23 +11,23 @@ module StagedEvent
       end
 
       def increment
-        @backoff_count += 1
+        @increments += 1
       end
 
       def reset
-        @backoff_count = 0
+        @increments = 0
       end
 
       def value
         # returns 1 until the timer has been incremented n times, after which it
         # returns n^2 (until reaching a set maximum)
-        backoff_time = [ 1, backoff_count - INCREMENTS_BEFORE_BACKOFF + 1 ].max**2
+        backoff_time = [ 1, increments - INCREMENTS_BEFORE_BACKOFF + 1 ].max**2
         [ backoff_time, MAX_VALUE ].min
       end
 
       private
 
-      attr_accessor :backoff_count
+      attr_accessor :increments
     end
   end
 end

--- a/lib/staged_event/publisher/backoff_timer.rb
+++ b/lib/staged_event/publisher/backoff_timer.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module StagedEvent
+  module Publisher
+    class BackoffTimer
+      INCREMENTS_BEFORE_BACKOFF = 5
+      MAX_VALUE = 25
+
+      def initialize
+        reset
+      end
+
+      def increment
+        @backoff_count += 1
+      end
+
+      def reset
+        @backoff_count = 0
+      end
+
+      def value
+        # returns 1 until the timer has been incremented n times, after which it
+        # returns n^2 (until reaching a set maximum)
+        backoff_time = [ 1, backoff_count - INCREMENTS_BEFORE_BACKOFF + 1 ].max**2
+        [ backoff_time, MAX_VALUE ].min
+      end
+
+      private
+
+      attr_accessor :backoff_count
+    end
+  end
+end

--- a/lib/staged_event/publisher/base.rb
+++ b/lib/staged_event/publisher/base.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module StagedEvent
+  module Publisher
+    class PublishFailedError < StandardError; end
+
+    class Base
+      def publish(_model)
+        raise StandardError, "You must implement the publish method"
+      end
+    end
+  end
+end

--- a/lib/staged_event/publisher_process.rb
+++ b/lib/staged_event/publisher_process.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module StagedEvent
+  class PublisherProcess
+    include Technologic
+
+    def initialize(publisher)
+      @publisher = publisher
+      @backoff_timer = Publisher::BackoffTimer.new
+    end
+
+    def run
+      loop do
+        sleep(backoff_timer.value)
+        publish_next_batch
+      end
+    rescue Publisher::PublishFailedError => exception
+      error :publish_failed, exception: exception
+      backoff_timer.increment
+      retry
+    end
+
+    private
+
+    attr_reader :publisher, :backoff_timer
+
+    def publish_next_batch
+      ActiveRecord::Base.connection_pool.with_connection do
+        ActiveRecord::Base.transaction do
+          events = Model.order(:created_at).limit(batch_size).lock("FOR UPDATE SKIP LOCKED")
+          if events.any?
+            events.each do |event|
+              publisher.publish(event)
+            end
+            events.destroy_all
+            backoff_timer.reset
+          else
+            backoff_timer.increment
+          end
+        end
+      end
+    end
+
+    def batch_size
+      Configuration.config.publisher.batch_size
+    end
+  end
+end

--- a/spec/lib/staged_event/publisher/backoff_timer_spec.rb
+++ b/spec/lib/staged_event/publisher/backoff_timer_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe StagedEvent::Publisher::BackoffTimer do
+  subject(:value) { instance.value }
+
+  let(:instance) { described_class.new }
+
+  context "when called on a new instance" do
+    it { is_expected.to eq(1) }
+  end
+
+  context "when repeatedly incremented" do
+    let(:sequence) do
+      Array.new(8) do
+        instance.increment
+        instance.value
+      end
+    end
+
+    before do
+      stub_const("StagedEvent::Publisher::BackoffTimer::INCREMENTS_BEFORE_BACKOFF", 2)
+    end
+
+    it "returns the expected sequence" do
+      expect(sequence).to eq([ 1, 1, 4, 9, 16, 25, 25, 25 ])
+    end
+
+    context "when reset is called" do
+      before do
+        sequence
+        instance.reset
+      end
+
+      it { is_expected.to eq(1) }
+    end
+  end
+end

--- a/spec/lib/staged_event/publisher_process_spec.rb
+++ b/spec/lib/staged_event/publisher_process_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+RSpec.describe StagedEvent::PublisherProcess do
+  describe "#run" do
+    subject(:run) { instance.run }
+
+    let(:instance) { described_class.new(publisher) }
+    let(:publisher) { instance_double(StagedEvent::Publisher::Base) }
+    let(:backoff_timer) do
+      instance_double(
+        StagedEvent::Publisher::BackoffTimer, {
+          reset: nil,
+          increment: nil,
+          value: backoff_timer_value,
+        }
+      )
+    end
+    let(:backoff_timer_value) { rand(1..100) }
+    let(:batch_size) { rand(2..5) }
+
+    before do
+      allow(StagedEvent::Configuration).to receive_message_chain(:config, :publisher, :batch_size).and_return(batch_size)
+      allow(StagedEvent::Publisher::BackoffTimer).to receive(:new).and_return(backoff_timer)
+      allow(publisher).to receive(:publish)
+      allow(instance).to receive(:loop).and_yield
+      allow(instance).to receive(:sleep)
+    end
+
+    context "when there are NO events to publish" do
+      before { run }
+
+      it "sleeps according to the backoff timer" do
+        expect(instance).to have_received(:sleep).with(backoff_timer_value)
+      end
+
+      it "increments the backoff timer" do
+        expect(backoff_timer).to have_received(:increment)
+      end
+
+      it "does not call publish" do
+        expect(publisher).not_to have_received(:publish)
+      end
+    end
+
+    context "when there are events to publish" do
+      let!(:all_events) do
+        StagedEvent::Model.create(
+          Array.new(batch_size + rand(1..5)) do
+            { topic: Faker::Lorem.word, data: Faker::Alphanumeric.alphanumeric }
+          end,
+        )
+      end
+      let(:events_published) { all_events.first(batch_size) }
+      let(:events_remaining) { all_events - events_published }
+
+      context "when publishing is successful" do
+        before { run }
+
+        it "sleeps according to the backoff timer" do
+          expect(instance).to have_received(:sleep).with(backoff_timer_value)
+        end
+
+        it "invokes the publisher for each event" do
+          events_published.each do |event|
+            expect(publisher).to have_received(:publish).with(event)
+          end
+        end
+
+        it "destroys all the published events" do
+          expect(StagedEvent::Model.count).to eq(events_remaining.size)
+          expect(StagedEvent::Model.ids).to match_array(events_remaining.map(&:id))
+        end
+
+        it "resets the backoff timer" do
+          expect(backoff_timer).to have_received(:reset)
+        end
+      end
+
+      context "when publishing raises an error" do
+        before do
+          publish_count = 0
+          allow(publisher).to receive(:publish) do
+            publish_count += 1
+            raise StagedEvent::Publisher::PublishFailedError if publish_count == 1
+          end
+          run
+        end
+
+        it "increments the backoff timer" do
+          expect(backoff_timer).to have_received(:increment)
+        end
+
+        it "retries the loop" do
+          expect(instance).to have_received(:sleep).twice
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,18 +1,46 @@
 # frozen_string_literal: true
 
-require 'faker'
-require 'staged_event'
-require 'sqlite3'
+require "byebug"
+require "database_cleaner"
+require "faker"
+require "sqlite3"
+require "active_support"
+require "active_support/core_ext"
+require "securerandom"
+
+require "staged_event"
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.around do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
+  end
+end
 
 ActiveRecord::Base.establish_connection(
-  adapter: 'sqlite3',
-  database: ':memory:'
+  adapter: "sqlite3",
+  database: ":memory:",
 )
 
 ActiveRecord::Schema.define do
-  create_table :staged_events, id: :uuid do |t|
+  create_table :staged_events, id: false do |t|
+    t.string :id, primary: true
     t.string :topic
     t.binary :data
     t.datetime :created_at, null: false
+  end
+end
+
+module StagedEvent
+  class Model < ActiveRecord::Base
+    self.primary_key = "id"
+
+    before_create -> { self.id = SecureRandom.uuid }
   end
 end

--- a/staged_event.gemspec
+++ b/staged_event.gemspec
@@ -17,8 +17,10 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "directive", ">= 0.23.1.1"
   spec.add_runtime_dependency "google-protobuf", ">= 3.8.0", "< 4.0.0"
 
+  spec.add_development_dependency "byebug"
+  spec.add_development_dependency "database_cleaner"
+  spec.add_development_dependency "faker"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "sqlite3"
-  spec.add_development_dependency "faker"
 end
 


### PR DESCRIPTION
This PR implements the framework for the "publisher" process that polls the database table for events to publish.

`StagedEvent::PublisherProcess` is what would be run as an independent, long-lived process. This class receives an instance of a "publisher" as a parameter, and lets that instance define how events are published.

`StagedEvent::Publisher::Base` defines the interface that a "publisher" needs to follow (just one method, `publish`). In a subsequent PR I'll add a stdout publisher for local testing purposes, and the actual Google Pub/Sub publisher.

Testing:

Manual testing can wait until the next PR when I add a simple publisher that just sends event data to the console. The focus for this PR is architecture.
