### PR TITLE
Rescue SignalException in long-lived processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Upcoming <!-- Add unreleased change notes here: -->
 - Added StagedEvent.save_proto! shortcut method with documentation
+- Rescue SignalException in publisher and subscriber processes
 
 ## v0.0.1
 *Release Date: 10/12/2021*

--- a/lib/staged_event/publisher_process.rb
+++ b/lib/staged_event/publisher_process.rb
@@ -18,6 +18,8 @@ module StagedEvent
       error :publish_failed, exception: exception.message
       backoff_timer.increment
       retry
+    rescue SignalException => exception
+      error :signal_exception, message: exception.message
     end
 
     private

--- a/lib/staged_event/subscriber_process.rb
+++ b/lib/staged_event/subscriber_process.rb
@@ -13,6 +13,8 @@ module StagedEvent
     rescue StandardError => exception
       error :subscriber_main_loop_failed, exception: exception.message
       retry
+    rescue SignalException => exception
+      error :signal_exception, message: exception.message
     end
 
     private


### PR DESCRIPTION
Otherwise we'll get sentry alerts before every monolith deployment